### PR TITLE
Fix haranoaji example description

### DIFF
--- a/zxjafont.tex
+++ b/zxjafont.tex
@@ -205,17 +205,17 @@ IPAexフォント。
 |oneweight|\>オプション指定時は以下の設定
 （1ウェイトのみ）が行われる：
 \begin{quote}\small\begin{verbatim}
-\setmainfont{HaranoAjiMincho-Regular}[BoldFont=HaranoAjiMincho-Medium]
+\setmainfont{HaranoAjiMincho-Regular}[BoldFont=HaranoAjiGothic-Medium]
 \setsansfont{HaranoAjiGothic-Medium}[BoldFont=HaranoAjiGothic-Medium]
 \setmonofont{HaranoAjiGothic-Medium}[BoldFont=HaranoAjiGothic-Medium]
 \end{verbatim}\end{quote}
-\Note 他の例と異なりゴシックで“|HaranoAjiMincho-Medium|”%
+\Note 他の例と異なり明朝で“|HaranoAjiGothic-Medium|”%
 （\Pkg{pxchfon}のマニュアルのプリセットの解説で\>|\setgothicfont|\>に
 割り当てられているフォント）が使われていることに注意。
 
 そして\>|bold|\>オプション指定時は以下の設定が行われる：
 \begin{quote}\small\begin{verbatim}
-\setmainfont{HaranoAjiMincho-Regular}[BoldFont=HaranoAjiMincho-Bold]
+\setmainfont{HaranoAjiMincho-Regular}[BoldFont=HaranoAjiGothic-Bold]
 \setsansfont{HaranoAjiGothic-Bold}[BoldFont=HaranoAjiGothic-Bold]
 \setmonofont{HaranoAjiGothic-Bold}[BoldFont=HaranoAjiGothic-Bold]
 \end{verbatim}\end{quote}


### PR DESCRIPTION
原ノ味フォントを使った oneweight および bold オプションの説明が間違っているのではないかと思いまして、修正をしてみました。

少なくとも本パッケージは HaranoAjiMincho-Medium を使わないと思います。